### PR TITLE
Disable auto updates on worker nodes

### DIFF
--- a/worker_node/cloud_init_worker.yaml
+++ b/worker_node/cloud_init_worker.yaml
@@ -72,6 +72,7 @@ write_files:
 
 runcmd:
   - adduser --disabled-password --gecos "" prometheus
+  - echo 'APT::Periodic::Unattended-Upgrade "0";' > /etc/apt/apt.conf.d/20auto-upgrades
   - /bin/consul-set-network.sh
   #- sudo hostnamectl set-hostname $(date +%s | sha256sum | base64 | head -c 32 ; echo)
 # host: ubuntu


### PR DESCRIPTION
Disable UnattendedUpgrades in APT configuration (new since Ubuntu 16.04) to prevent unintended up-scaling by MiCADO.

Fixes #2 