### PR TITLE
Fix $GITHUB_URL in micado_cloud_init.yaml

### DIFF
--- a/micado_cloud_init.yaml
+++ b/micado_cloud_init.yaml
@@ -353,7 +353,7 @@ runcmd:
   - resolvconf -u
   - echo nameserver 8.8.8.8 >> /etc/resolv.conf
 #download config files
-  - export GITHUB_URL=https://raw.githubusercontent.com/micado-scale/micado/0.3.1
+  - export GITHUB_URL=https://raw.githubusercontent.com/micado-scale/micado/0.3.x
   - curl -L $GITHUB_URL/configs/executor_config.sh --create-dirs -o /etc/prometheus_executor/conf.sh
   - curl -L $GITHUB_URL/configs/consul_checks.json --create-dirs -o /etc/consul/checks.json
 #change health check ip address for host ip


### PR DESCRIPTION
Broken link... Change from _.../micado/0.3.1_ to _.../micado/0.3.x_

NB. This is going to break again whenever it is merged to another branch